### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/odluser1372466/f00ff85f-6483-4dd7-b7b1-56afc5f4166b/ec01cebb-32af-4827-b900-3a0485263d37/_apis/work/boardbadge/8dae7541-b529-4390-a04f-6df36fd4e14f)](https://dev.azure.com/odluser1372466/f00ff85f-6483-4dd7-b7b1-56afc5f4166b/_boards/board/t/ec01cebb-32af-4827-b900-3a0485263d37/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/odluser1372466/f00ff85f-6483-4dd7-b7b1-56afc5f4166b/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.